### PR TITLE
Set job metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.2.0
+-----
+- implement `set_metadata` method to associate an arbitrary mapping to a job
+- pass `metadata` kwarg to `create_job`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='watchbot_progress',
-    version='0.1.1',
+    version='0.2.0',
     description=u"Watchbot reduce-mode helpers for python",
     long_description='See https://github.com/mapbox/watchbot-progress-py',
     classifiers=[],

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -25,6 +25,9 @@ class MockBase(WatchbotProgress):
     def send_message(self, message, subject):
         return True
 
+    def set_metadata(self, jobid, metdata):
+        return None
+
 
 def test_create_jobs(monkeypatch):
     monkeypatch.setenv('WorkTopic', 'abc123')
@@ -104,3 +107,17 @@ def test_Part_already_failed(monkeypatch):
                 # sees that the overall job failed and will not execute this code
                 raise NotImplementedError("You'll never get here")
         assert 'already failed' in str(e)
+
+
+def test_create_jobs_metadata(monkeypatch):
+    monkeypatch.setenv('WorkTopic', 'abc123')
+    monkeypatch.setenv('ProgressTable', 'arn::table/foo')
+
+    class MockProgress(MockBase):
+        pass
+
+    meta = {'foo': 'bar'}
+
+    with patch('watchbot_progress.uuid.uuid4', new=lambda: '000-123'):
+        with patch('watchbot_progress.WatchbotProgress', new=MockProgress):
+            assert create_job(parts, metadata=meta) == '000-123'

--- a/tests/test_watchbot_progress.py
+++ b/tests/test_watchbot_progress.py
@@ -92,3 +92,14 @@ def test_incomplete_part(client, monkeypatch):
     client.return_value.Table.return_value.update_item.return_value = item
     s = WatchbotProgress().complete_part('123', 1)
     assert s is False
+
+
+@patch('watchbot_progress.boto3.resource')
+def test_set_metadata(client, monkeypatch):
+    monkeypatch.setenv('WorkTopic', 'abc123')
+    monkeypatch.setenv('ProgressTable', 'arn::table/foo')
+
+    item = 'sentinel'
+    client.return_value.Table.return_value.update_item.return_value = item
+    WatchbotProgress().set_metadata('123', {'a': 1})
+    assert client.called

--- a/watchbot_progress/__init__.py
+++ b/watchbot_progress/__init__.py
@@ -127,7 +127,7 @@ class WatchbotProgress(object):
             Key={'id': jobid},
             ExpressionAttributeNames={'#m': 'metadata'},
             ExpressionAttributeValues={':m': metadata},
-            UpdateExpression='set #m :m')
+            UpdateExpression='set #m = :m')
 
     def send_message(self, message, subject):
         """Function wrapper to facilitate partial application"""


### PR DESCRIPTION
resolves #2 

implements the `set_metadata` method and allows metadata to be associated with a job via the `create_job` function.