### PR TITLE
send metadata in reduce message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 0.2.1
 -----
-- send metadata with reduce message #5
+- send metadata with map and reduce messages #5
 
 0.2.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.2.1
+-----
+- send metadata with reduce message #5
+
 0.2.0
 -----
 - implement `set_metadata` method to associate an arbitrary mapping to a job

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='watchbot_progress',
-    version='0.2.0',
+    version='0.2.1',
     description=u"Watchbot reduce-mode helpers for python",
     long_description='See https://github.com/mapbox/watchbot-progress-py',
     classifiers=[],

--- a/watchbot_progress/__init__.py
+++ b/watchbot_progress/__init__.py
@@ -194,4 +194,9 @@ def Part(jobid, partid, table_arn=None, topic_arn=None, **kwargs):
     else:
         all_done = progress.complete_part(jobid, partid)
         if all_done:
-            progress.send_message({'jobid': jobid}, subject='reduce')
+            status = progress.status(jobid)
+            metadata = status.get('metadata', None)
+            message = {
+                'jobid': jobid,
+                'metadata': metadata}
+            progress.send_message(message, subject='reduce')

--- a/watchbot_progress/__init__.py
+++ b/watchbot_progress/__init__.py
@@ -156,9 +156,12 @@ def create_job(parts, jobid=None, workers=8, table_arn=None, topic_arn=None, met
     if metadata:
         progress.set_metadata(jobid, metadata)
 
-    annotated_parts = [
-        dict(partid=partid, jobid=jobid, **part)
-        for partid, part in enumerate(parts)]
+    annotated_parts = []
+    for partid, part in enumerate(parts):
+        part.update(partid=partid)
+        part.update(jobid=jobid)
+        part.update(metadata=metadata)
+        annotated_parts.append(part)
 
     # Send SNS message for each part, concurrently
     _send_message = partial(progress.send_message, subject='map')


### PR DESCRIPTION
This PR will attach the `metadata` to the final `Subject=reduce` message.

My only thought on improving this is that we could somehow pass arbitrary data between the context manager and the code block. But that might be a rabbit hole for another PR.