### PR TITLE
implement fail_job_on [wip]

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,6 +1,6 @@
 import pytest
-from watchbot_progress import create_job, Part, WatchbotProgress
-from mock import patch, PropertyMock
+from watchbot_progress import create_job, Part, WatchbotProgress, JobFailed
+from mock import patch
 
 parts = [
     {'source': 'a.tif'},
@@ -69,29 +69,6 @@ def test_Part_job_done(monkeypatch):
             msg['source']
 
 
-def test_Part_failure(monkeypatch):
-    monkeypatch.setenv('WorkTopic', 'abc123')
-    monkeypatch.setenv('ProgressTable', 'arn::table/foo')
-
-    msg = {'source': 'a.tif', 'partid': 1, 'jobid': '123'}
-
-    class MockProgress(MockBase):
-        def fail_job(self, jobid, reason):
-            pass
-
-    class CustomException(Exception):
-        pass
-
-    # The exception will get caught by the Part context block and
-    # the job will be marked as failed and the exeption re-raised
-    with patch('watchbot_progress.WatchbotProgress', new=MockProgress):
-        with pytest.raises(CustomException) as e:
-            with Part(**msg):
-                raise CustomException('processing failed')
-        assert 'processing failed' in str(e)
-        # TODO assert that fail_job got called
-
-
 def test_Part_already_failed(monkeypatch):
     monkeypatch.setenv('WorkTopic', 'abc123')
     monkeypatch.setenv('ProgressTable', 'arn::table/foo')
@@ -100,10 +77,13 @@ def test_Part_already_failed(monkeypatch):
         def status(self, x):
             return {'progress': 0.3, 'failed': True}
 
+    class CustomException(Exception):
+        pass
+
     with patch('watchbot_progress.WatchbotProgress', new=MockProgress):
         msg = {'source': 'a.tif', 'partid': 1, 'jobid': '123'}
-        with pytest.raises(RuntimeError) as e:
-            with Part(**msg):
+        with pytest.raises(JobFailed) as e:
+            with Part(fail_job_on=[CustomException], **msg):
                 # sees that the overall job failed and will not execute this code
                 raise NotImplementedError("You'll never get here")
         assert 'already failed' in str(e)
@@ -121,3 +101,35 @@ def test_create_jobs_metadata(monkeypatch):
     with patch('watchbot_progress.uuid.uuid4', new=lambda: '000-123'):
         with patch('watchbot_progress.WatchbotProgress', new=MockProgress):
             assert create_job(parts, metadata=meta) == '000-123'
+
+
+@patch('watchbot_progress.WatchbotProgress.fail_job')
+@patch('watchbot_progress.WatchbotProgress.status')
+def test_Part_fail_job_on(status, fail_job, monkeypatch):
+    monkeypatch.setenv('WorkTopic', 'abc123')
+    monkeypatch.setenv('ProgressTable', 'arn::table/foo')
+
+    class CustomException(Exception):
+        pass
+
+    # the job WILL be marked as failed, the exeption is still re-raised
+    with pytest.raises(CustomException):
+        with Part(jobid=2, partid=2, fail_job_on=[CustomException]):
+            raise CustomException()
+    fail_job.assert_called_once_with(2, 2)
+
+
+@patch('watchbot_progress.WatchbotProgress.fail_job')
+@patch('watchbot_progress.WatchbotProgress.status')
+def test_Part_dont_fail_job_on(status, fail_job, monkeypatch):
+    monkeypatch.setenv('WorkTopic', 'abc123')
+    monkeypatch.setenv('ProgressTable', 'arn::table/foo')
+
+    class CustomException(Exception):
+        pass
+
+    # the job will NOT be marked as failed, the exeption is still re-raised
+    with pytest.raises(CustomException):
+        with Part(jobid=2, partid=2, fail_job_on=[ZeroDivisionError]):
+            raise CustomException()
+    fail_job.assert_not_called()


### PR DESCRIPTION
This PR changes the default behavior of the Part context manager to behave more like standard ecs-watchbot. After this PR, by default, encountering an exception for one single part will no longer mark the entire reduce mode job to fail. This gives subsequent parts and retries a chance to succeed, defering the retry logic entierly to ecs-watchbot. 

Resolves #3

If there is no way to fail a job, there's also no reason to check for job status first, a slight performance boost.

For cases where you want to fail the whole job, you can explicitly fail on certain exceptions

```
with Part(jobid=2, partid=123, fail_job_on=[OMGStopNow]):
```

This is a backwards-incompatible change but makes the behavior more tractable for common use cases.