### PR TITLE
only send reduce message once per job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.8.0
+-----
+- Modify the Part context manager to ensure the reduce message gets sent only once per job
+
 0.7.0
 -----
 - Send SNS messages in batch using boto3 thread safe method

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='watchbot_progress',
-    version='0.7.0',
+    version='0.8.0',
     description=u"Watchbot reduce-mode helpers for python",
     long_description='See https://github.com/mapbox/watchbot-progress-py',
     classifiers=[],


### PR DESCRIPTION
resolves #22 

The implementation in this PR uses the job metadata to track if the reduce message has been sent. If you re-run an already completed Part after the message has already been sent, you get a warning and noop.

There is a tiny flaw in the present implementation - this code is not atomic and subject to a (very unlikely but possible) race condition. If another process sends the reduce message in between fetching the status (line 114) and our decision point (line 120) we could theoretically see multiple messages. I tried to trigger this with concurrent threads and fuzz-testing but was not able to send more than one message - I think this is safe enough for ecs-watchbot use. If someone feels otherwise, we could try to rewrite the whole operation atomic using [redis-py pipelines](https://github.com/andymccurdy/redis-py/#pipelines).

I decided not to implement any code to check the low-level `complete_part` function. After thinking about it, marking a part as complete should be a safe, declarative and idempotent - no need to even warn about it. Plus checking for the part completion before marking it would need to be done in an atomic transaction and add unnecessary overhead to each backend.

Ready for review @dnomadb @vincentsarago 