### PR TITLE
Adds ability to provide a custom callback instead of sending a reduce message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.9.0
+-----
+- Adds ability to provide a custom callback to the Part context manager in place of sending a reduce message
+
 0.8.0
 -----
 - Modify the Part context manager to ensure the reduce message gets sent only once per job

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='watchbot_progress',
-    version='0.8.0',
+    version='0.9.0',
     description=u"Watchbot reduce-mode helpers for python",
     long_description='See https://github.com/mapbox/watchbot-progress-py',
     classifiers=[],

--- a/tests/test_interface_redis.py
+++ b/tests/test_interface_redis.py
@@ -10,6 +10,22 @@ parts = [
     {'source': 'b.tif'},
     {'source': 'c.tif'}]
 
+@pytest.fixture
+def CustomCallback():
+    class OnReduce():
+        def __init__(self):
+            self.called = False
+            pass
+        def on_reduce(self, message, topic, subject):
+            self.called = True
+            self.message = message
+            self.topic = topic
+            self.subject = subject
+        def assert_called_once(self):
+            assert self.called
+
+    return OnReduce()
+
 
 @patch('redis.StrictRedis', mock_strict_redis_client)
 @patch('watchbot_progress.main.sns_worker')
@@ -54,23 +70,6 @@ def test_progress_all_done(aws_send_message, sns_worker, monkeypatch):
         assert sns_worker.call_args[1].get('subject') == 'map'
         aws_send_message.assert_called_once()
         assert aws_send_message.call_args[1].get('subject') == 'reduce'
-
-
-@pytest.fixture
-def CustomCallback():
-    class OnReduce():
-        def __init__(self):
-            self.called = False
-            pass
-        def on_reduce(self, message, topic, subject):
-            self.called = True
-            self.message = message
-            self.topic = topic
-            self.subject = subject
-        def assert_called_once(self):
-            assert self.called
-
-    return OnReduce()
 
 
 @patch('redis.StrictRedis', mock_strict_redis_client)

--- a/tests/test_interface_redis.py
+++ b/tests/test_interface_redis.py
@@ -56,6 +56,45 @@ def test_progress_all_done(aws_send_message, sns_worker, monkeypatch):
         assert aws_send_message.call_args[1].get('subject') == 'reduce'
 
 
+@pytest.fixture
+def CustomCallback():
+    class OnReduce():
+        def __init__(self):
+            self.called = False
+            pass
+        def on_reduce(self, message, topic, subject):
+            self.called = True
+            self.message = message
+            self.topic = topic
+            self.subject = subject
+        def assert_called_once(self):
+            assert self.called
+
+    return OnReduce()
+
+
+@patch('redis.StrictRedis', mock_strict_redis_client)
+@patch('watchbot_progress.main.sns_worker')
+def test_progress_all_done_custom_on_reduce(sns_worker, CustomCallback, monkeypatch):
+        monkeypatch.setenv('WorkTopic', 'abc123')
+        progress = RedisProgress()
+
+        jobid = create_job(parts, progress=progress)
+        for i in range(3):
+            with Part(jobid, i, progress=progress, on_reduce=CustomCallback.on_reduce):
+                pass
+
+        assert progress.status(jobid)['remaining'] == 0
+
+        # 3 map messages and 1 reduce message sent
+        sns_worker.assert_called_once()
+        assert len(sns_worker.call_args[0][0]) == 3
+        assert sns_worker.call_args[1].get('subject') == 'map'
+
+        CustomCallback.assert_called_once()
+        assert CustomCallback.subject == 'reduce'
+
+
 @patch('redis.StrictRedis', mock_strict_redis_client)
 @patch('watchbot_progress.main.sns_worker')
 @patch('watchbot_progress.main.aws_send_message')

--- a/tests/test_interface_redis.py
+++ b/tests/test_interface_redis.py
@@ -1,6 +1,6 @@
 from watchbot_progress import create_job, Part
 from watchbot_progress.backends.redis import RedisProgress
-from mock import patch
+from mock import patch, Mock
 from mockredis import mock_strict_redis_client
 import pytest
 
@@ -9,22 +9,6 @@ parts = [
     {'source': 'a.tif'},
     {'source': 'b.tif'},
     {'source': 'c.tif'}]
-
-@pytest.fixture
-def CustomCallback():
-    class OnReduce():
-        def __init__(self):
-            self.called = False
-            pass
-        def on_reduce(self, message, topic, subject):
-            self.called = True
-            self.message = message
-            self.topic = topic
-            self.subject = subject
-        def assert_called_once(self):
-            assert self.called
-
-    return OnReduce()
 
 
 @patch('redis.StrictRedis', mock_strict_redis_client)
@@ -74,13 +58,13 @@ def test_progress_all_done(aws_send_message, sns_worker, monkeypatch):
 
 @patch('redis.StrictRedis', mock_strict_redis_client)
 @patch('watchbot_progress.main.sns_worker')
-def test_progress_all_done_custom_on_reduce(sns_worker, CustomCallback, monkeypatch):
+def test_progress_all_done_custom_on_reduce(sns_worker, monkeypatch):
         monkeypatch.setenv('WorkTopic', 'abc123')
         progress = RedisProgress()
-
+        on_reduce = Mock()
         jobid = create_job(parts, progress=progress)
         for i in range(3):
-            with Part(jobid, i, progress=progress, on_reduce=CustomCallback.on_reduce):
+            with Part(jobid, i, progress=progress, on_reduce=on_reduce):
                 pass
 
         assert progress.status(jobid)['remaining'] == 0
@@ -90,8 +74,8 @@ def test_progress_all_done_custom_on_reduce(sns_worker, CustomCallback, monkeypa
         assert len(sns_worker.call_args[0][0]) == 3
         assert sns_worker.call_args[1].get('subject') == 'map'
 
-        CustomCallback.assert_called_once()
-        assert CustomCallback.subject == 'reduce'
+        on_reduce.assert_called_once()
+        assert on_reduce.call_args[1].get('subject') == 'reduce'
 
 
 @patch('redis.StrictRedis', mock_strict_redis_client)


### PR DESCRIPTION
This adds ability to provide a custom callback function to run _instead of_ sending a `"reduce"` message to the provided topic.

cc @perrygeo 